### PR TITLE
Removes performKeyEquivalent method

### DIFF
--- a/src/Avalonia.Native.OSX/window.mm
+++ b/src/Avalonia.Native.OSX/window.mm
@@ -961,11 +961,6 @@ NSArray* AllLoopModes = [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSEvent
     _lastKeyHandled = _parent->BaseEvents->RawKeyEvent(type, timestamp, modifiers, key);
 }
 
-- (BOOL)performKeyEquivalent:(NSEvent *)event
-{
-    return _lastKeyHandled;
-}
-
 - (void)keyDown:(NSEvent *)event
 {
     [self keyboardEvent:event withType:KeyDown];


### PR DESCRIPTION
This PR fixes a Cmd+C / Cmd+V problem that break the functionality (we weren't able to paste the clipboard content most of the times). 

If well this change seems to fix the problem, i don't fully understand all the keystroke logic flow and the interaction between avalonia, avalonia.native and the osx system calls so, any feedback would be great.